### PR TITLE
Fix refresh when the project disappears in Sentry.

### DIFF
--- a/pkg/provider/projects.go
+++ b/pkg/provider/projects.go
@@ -135,7 +135,7 @@ func (k *sentryProvider) projectRead(ctx context.Context, req *rpc.ReadRequest) 
 	}
 	project, err := k.sentryClient.GetProject(sentry.Organization{Slug: &organizationSlug}, slug)
 	if err != nil {
-		if apiError, ok := err.(*sentry.APIError); ok {
+		if apiError, ok := err.(sentry.APIError); ok {
 			if apiError.StatusCode == 404 {
 				// The project is not there, delete it from stack state.
 				return &rpc.ReadResponse{}, nil

--- a/pkg/provider/projects_test.go
+++ b/pkg/provider/projects_test.go
@@ -253,6 +253,21 @@ func TestProjectRead(t *testing.T) {
 	})
 }
 
+func TestProjectRead404(t *testing.T) {
+	ctx := context.Background()
+	prov := sentryProvider{
+		sentryClient: &sentryClientMock{
+			getProject: func(org sentry.Organization, projslug string) (sentry.Project, error) {
+				return sentry.Project{}, &sentry.APIError{Detail: "not found", StatusCode: 404}
+			},
+		},
+	}
+	resp, err := prov.projectRead(ctx, &rpc.ReadRequest{Id: "org-slug/proj-slug"})
+	assert.Nil(t, err)
+	assert.Equal(t, resp.GetId(), "")
+	assert.Nil(t, resp.GetProperties())
+}
+
 func TestProjectDelete(t *testing.T) {
 	ctx := context.Background()
 	deleteCalled := false

--- a/pkg/provider/projects_test.go
+++ b/pkg/provider/projects_test.go
@@ -258,7 +258,7 @@ func TestProjectRead404(t *testing.T) {
 	prov := sentryProvider{
 		sentryClient: &sentryClientMock{
 			getProject: func(org sentry.Organization, projslug string) (sentry.Project, error) {
-				return sentry.Project{}, &sentry.APIError{Detail: "not found", StatusCode: 404}
+				return sentry.Project{}, sentry.APIError{Detail: "not found", StatusCode: 404}
 			},
 		},
 	}


### PR DESCRIPTION
This fixes an issue with `projectRead` treating the 404 during `read` as a generic error instead of as a signal that the resource is gone.